### PR TITLE
remove unnecessary 8 byte padding

### DIFF
--- a/xtea.js
+++ b/xtea.js
@@ -104,6 +104,9 @@ function doBlocks( encryption, msg, key, mode, ivbuf, skippad ) {
 
   var length = msg.length;
   var pad = 8 - (length & 7);
+  if ( pad == 8 ) {
+	  pad = 0;
+  }
 
   if ( skippad || ! encryption ) {
     if (pad !== 8) {


### PR DESCRIPTION
When the buffer is exactly aligned by 8 bytes, the remainder of `& 7` is `0`, resulting in `8-0` bytes of padding instead of `0`.